### PR TITLE
chore: pin rust toolchain to 1.94.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.94.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
Fix the Rust version used across development and CI to avoid reproducibility issues between environments. Include rustfmt and clippy components by default.