### PR TITLE
chore: tune release profile for performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,10 @@ mem_storage = "0.1.1"
 primitive-types = "0.12.1"
 hex = "0.4"
 rusty-hook = "0.11.2"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+strip = "symbols"
+opt-level = 3


### PR DESCRIPTION
Enable LTO, single codegen unit, panic=abort, symbol stripping and opt-level=3 to produce a leaner and faster release binary. This aligns with the 'blazingly fast' claim in the crate description.