### PR TITLE
docs: add CHANGELOG, CONTRIBUTING, PR template; fix README_CRATE example

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- 1-3 bullet points on what changes. -->
+
+## Why
+
+<!-- The motivation. Link to a related issue if applicable. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change
+- [ ] Documentation / tooling only
+
+## Checklist
+
+- [ ] `cargo build --all-targets` passes
+- [ ] `cargo test` passes
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo doc --no-deps` passes without warnings
+- [ ] Added / updated tests where relevant
+- [ ] Updated `CHANGELOG.md` under `## [Unreleased]`
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+## Breaking changes
+
+<!-- If applicable, describe the breaking change and the migration path for consumers. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Project baseline documentation (`CHANGELOG.md`, `CONTRIBUTING.md`, PR template).
+- `.env.example` template to replace the previously tracked `.env`.
+- Pinned Rust toolchain via `rust-toolchain.toml` (1.94.0).
+- Optimized `[profile.release]` (LTO, single codegen unit, panic=abort, symbol stripping).
+
+### Changed
+- Fixed broken Rust example in `README_CRATE.md` (missing semicolon and stale
+  variable name).
+- Cleaned up and deduplicated `.gitignore`.
+
+### Removed
+- Unmaintained `rusty-hook` dependency and `.rusty-hook.toml` configuration.
+  Pre-commit and pre-push checks are moving to CI.
+- `.env` stopped being tracked (its contents moved to `.env.example`).
+
+## [0.1.4] - 2024-10-09
+
+### Added
+- `--debug-level` CLI argument to control verbosity of the interpreter output.
+
+### Changed
+- Documentation updates across `README.md`.
+
+## [0.1.3] - 2023-10-16
+
+### Added
+- `src/lib.rs` exposing the core types so the crate can be consumed as a
+  library, not only as a binary.
+
+## [0.1.2] - 2023-09-19
+
+### Changed
+- `Cargo.toml` metadata polish (package info, readme, excludes) for crates.io.
+
+## [0.1.1] - 2023-09-19
+
+### Fixed
+- Install script.
+
+## [0.1.0] - 2023-09-11
+
+### Added
+- Initial public release.
+- EVM bytecode interpreter covering most opcodes (arithmetic, bitwise,
+  comparison, stack, memory, storage, control flow, logs, system).
+- In-memory state with optional RPC fork support via `ethers`.
+- CLI binary `evm-rs` with configurable caller, origin, address, value,
+  calldata, fork URL and debug level.
+
+[Unreleased]: https://github.com/Yashiru/evm-rs-emulator/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/Yashiru/evm-rs-emulator/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/Yashiru/evm-rs-emulator/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/Yashiru/evm-rs-emulator/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/Yashiru/evm-rs-emulator/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/Yashiru/evm-rs-emulator/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to evm-rs-emulator
+
+Thanks for your interest in contributing! This document describes how to get
+set up and what is expected of a pull request.
+
+## Getting started
+
+```bash
+git clone https://github.com/Yashiru/evm-rs-emulator
+cd evm-rs-emulator
+cargo build
+cargo test
+```
+
+The Rust toolchain pinned in `rust-toolchain.toml` is used automatically by
+rustup — you should not need to install a specific version manually.
+
+## Development workflow
+
+1. Fork the repository (or create a branch if you have write access).
+2. Create a branch with a descriptive prefix:
+   - `feat/<slug>` for new features
+   - `fix/<slug>` for bug fixes
+   - `refactor/<slug>` for internal cleanups that do not change behavior
+   - `perf/<slug>` for performance work
+   - `test/<slug>` for test-only changes
+   - `docs/<slug>` for documentation
+   - `chore/<slug>` for tooling / repo hygiene
+   - `ci/<slug>` for CI workflow changes
+3. Make **atomic commits**. Each commit must pass:
+   - `cargo build --all-targets`
+   - `cargo test`
+   - `cargo fmt --all -- --check`
+   - `cargo clippy --all-targets -- -D warnings`
+   - `cargo doc --no-deps`
+4. Write commit messages following
+   [Conventional Commits](https://www.conventionalcommits.org/):
+   ```
+   <type>(<scope>): <short imperative summary>
+
+   <optional body explaining WHY, not WHAT>
+
+   <optional footer: BREAKING CHANGE:, refs #issue>
+   ```
+5. Open a pull request against `master` and fill the PR template checklist.
+
+## Code style
+
+- Rust edition 2021.
+- `rustfmt` enforced via `rustfmt.toml`.
+- `clippy` with `-D warnings` enforced.
+- Public items should carry rustdoc documentation.
+
+## Tests
+
+- Unit tests live next to the code they exercise, inside `#[cfg(test)] mod tests`.
+- Integration tests go under `tests/` at the workspace root.
+- When fixing a bug, add a regression test that fails before the fix and
+  passes after.
+
+## Release process
+
+Maintainers only:
+
+1. Bump `version` in `Cargo.toml`.
+2. Move the `[Unreleased]` section of `CHANGELOG.md` under the new version
+   number and today's date.
+3. Commit (`chore(release): X.Y.Z`) and create an annotated tag
+   (`git tag -a vX.Y.Z -m "X.Y.Z"`).
+4. Push tag and master.
+5. `cargo publish --dry-run` then `cargo publish`.
+
+## Reporting issues
+
+Open a GitHub issue describing:
+- What you were trying to do.
+- What happened.
+- What you expected.
+- The Rust version, OS, and a minimal reproducer when possible.

--- a/README_CRATE.md
+++ b/README_CRATE.md
@@ -26,17 +26,17 @@ fn main() {
     0x00, 0x00, 0xc4, 0x11, 0xe8,
   ];
   let origin: Option<[u8; 20]> = None;
-  let address: Option<[u8; 20]> = None
+  let address: Option<[u8; 20]> = None;
   let value: Option<[u8; 32]> = None;
   let data: Option<Vec<u8>> = None;
   let bytecode: Vec<u8> = vec![0x60, 0xff, 0x60, 0xff];
-  
+
   // Create a new interpreter
   let mut runner =
       Runner::new(caller, origin, address, value, data, None);
 
   // Run all the bytecode
-  let _ = interpreter.interpret(bytecode, Some(255), true);
+  let _ = runner.interpret(bytecode.clone(), Some(255), true);
 
   // Or run the bytecode OPCODE by OPCODE
   runner.bytecode = bytecode;


### PR DESCRIPTION
- Initial CHANGELOG following the Keep a Changelog format, backfilling entries for released 0.1.x versions.
- CONTRIBUTING describes the branch naming conventions, atomic commit requirements, code style, test expectations and release process.
- PR template embeds a quality checklist for reviewers.
- Fix the Usage example in README_CRATE.md: add the missing semicolon and rename a stale 'interpreter' binding to match README.md.